### PR TITLE
Zeroize entropy after a contribution is made and switched to ChaCha20Rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "hex-literal",
  "proptest",
  "rand",
+ "rand_chacha",
  "rayon",
  "ruint",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ dependencies = [
  "async-session",
  "axum",
  "axum-extra",
+ "base64 0.13.0",
  "chrono",
  "clap",
  "cli-batteries",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ cli-batteries = { version = "0.3.3", features = ["signals", "prometheus", "meter
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 axum = { version = "0.5.15", features = ["headers"] }
 axum-extra = { version = "0.3.7", features = ["erased-json"] }
+base64 = "0.13"
 hyper = "0.14"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,10 @@ cargo fmt && cargo clippy --all-targets --all-features && cargo build --all-targ
 - kzg-ceremony-poc.fly.dev
 - You can use the endpoint `/hello_world` to check that the server is running
 
+## Registering for GitHub OAuth
+
+Register for Github OAuth access [here](https://github.com/settings/developers).
+
 ## Registering for Sign-in-with-Ethereum
 
 See the documentation [here](https://docs.login.xyz/servers/oidc-provider/hosted-oidc-provider).
@@ -55,7 +59,7 @@ To register, use the REST API:
 ```shell
 curl -X POST https://oidc.signinwithethereum.org/register \
    -H 'Content-Type: application/json' \
-   -d '{"redirect_uris": ["http://127.0.0.1:3000/auth/callback/eth"]}'
+   -d '{"redirect_uris": ["http://127.0.0.1:3000/auth/callback/eth", "https://kzg-ceremony-sequencer-dev.fly.dev/auth/callback/eth"]}'
 ```
 
 ```json
@@ -65,7 +69,8 @@ curl -X POST https://oidc.signinwithethereum.org/register \
   "registration_access_token": "....",
   "registration_client_uri": "https://oidc.signinwithethereum.org/client/9b49de48-d198-47e7-afff-7ee26cbcbc95",
   "redirect_uris": [
-    "http://127.0.0.1:3000/auth/callback/eth"
+    "http://127.0.0.1:3000/auth/callback/eth",
+    "https://kzg-ceremony-sequencer-dev.fly.dev/auth/callback/eth"
   ]
 }
 ```

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.34"
 tracing = "0.1.36"
 zeroize = "1.5.7"
 hex-literal = "0.3.4"
+rand_chacha = "0.3.1"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -13,7 +13,7 @@ pub struct BatchContribution {
 impl BatchContribution {
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]
     pub fn receipt(&self) -> Vec<G2> {
-        self.contributions.iter().map(|c| c.pubkey).collect()
+        self.contributions.iter().map(|c| c.pot_pubkey).collect()
     }
 
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -13,7 +13,7 @@ pub struct BatchContribution {
 impl BatchContribution {
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]
     pub fn receipt(&self) -> Vec<G2> {
-        self.contributions.iter().map(|c| c.pot_pubkey).collect()
+        self.contributions.iter().map(|c| c.pubkey).collect()
     }
 
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -4,18 +4,19 @@ use std::collections::HashMap;
 use tracing::instrument;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Contribution {
     #[serde(flatten)]
     pub powers: Powers,
 
-    pub pubkey: G2,
+    pub pot_pubkey: G2,
 }
 
 impl Contribution {
     /// Check if the contribution has any entropy added.
     #[must_use]
     pub fn has_entropy(&self) -> bool {
-        self.pubkey != G2::one()
+        self.pot_pubkey != G2::one()
     }
 
     /// Adds entropy to this contribution. Can be called multiple times.
@@ -27,14 +28,14 @@ impl Contribution {
         // Validate points
         E::validate_g1(&self.powers.g1)?;
         E::validate_g2(&self.powers.g2)?;
-        E::validate_g2(&[self.pubkey])?;
+        E::validate_g2(&[self.pot_pubkey])?;
 
         // Add entropy
         E::add_entropy_g1(entropy, &mut self.powers.g1)?;
         E::add_entropy_g2(entropy, &mut self.powers.g2)?;
-        let mut temp = [G2::zero(), self.pubkey];
+        let mut temp = [G2::zero(), self.pot_pubkey];
         E::add_entropy_g2(entropy, &mut temp)?;
-        self.pubkey = temp[1];
+        self.pot_pubkey = temp[1];
 
         Ok(())
     }
@@ -54,7 +55,7 @@ impl Contribution {
         }
 
         // Zero values are never allowed
-        if self.pubkey == G2::zero() {
+        if self.pot_pubkey == G2::zero() {
             return Err(CeremonyError::ZeroPubkey);
         }
         for (i, g1) in self.powers.g1.iter().enumerate() {
@@ -77,7 +78,7 @@ impl Contribution {
         }
 
         // If there is no entropy yet, all values must be one.
-        if self.pubkey == G2::one()
+        if self.pot_pubkey == G2::one()
             && self.powers.g1.iter().all(|g1| *g1 == G1::one())
             && self.powers.g2.iter().all(|g2| *g2 == G2::one())
         {
@@ -103,7 +104,7 @@ impl Contribution {
             if *g2 == G2::one() {
                 return Err(CeremonyError::InvalidG2One(i));
             }
-            if i > 1 && *g2 == self.pubkey {
+            if i > 1 && *g2 == self.pot_pubkey {
                 return Err(CeremonyError::InvalidG2Pubkey(i));
             }
             if let Some(j) = set.get(g2) {
@@ -123,8 +124,8 @@ mod test {
     #[test]
     fn contribution_json() {
         let value = Contribution {
-            powers: Powers::new(2, 4),
-            pubkey: G2::one(),
+            powers:     Powers::new(2, 4),
+            pot_pubkey: G2::one(),
         };
         let json = serde_json::to_value(&value).unwrap();
         assert_eq!(
@@ -144,7 +145,7 @@ mod test {
                 "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
                 ]
             },
-            "pubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+            "potPubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
             })
         );
         let deser = serde_json::from_value::<Contribution>(json).unwrap();

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -4,18 +4,19 @@ use std::collections::HashMap;
 use tracing::instrument;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Contribution {
     #[serde(flatten)]
     pub powers: Powers,
 
-    pub pubkey: G2,
+    pub pot_pubkey: G2,
 }
 
 impl Contribution {
     /// Check if the contribution has any entropy added.
     #[must_use]
     pub fn has_entropy(&self) -> bool {
-        self.pubkey != G2::one()
+        self.pot_pubkey != G2::one()
     }
 
     /// Adds entropy to this contribution. Can be called multiple times.
@@ -27,14 +28,14 @@ impl Contribution {
         // Validate points
         E::validate_g1(&self.powers.g1)?;
         E::validate_g2(&self.powers.g2)?;
-        E::validate_g2(&[self.pubkey])?;
+        E::validate_g2(&[self.pot_pubkey])?;
 
         // Add entropy
         E::add_entropy_g1(entropy, &mut self.powers.g1)?;
         E::add_entropy_g2(entropy, &mut self.powers.g2)?;
-        let mut temp = [G2::zero(), self.pubkey];
+        let mut temp = [G2::zero(), self.pot_pubkey];
         E::add_entropy_g2(entropy, &mut temp)?;
-        self.pubkey = temp[1];
+        self.pot_pubkey = temp[1];
 
         Ok(())
     }
@@ -54,7 +55,7 @@ impl Contribution {
         }
 
         // Zero values are never allowed
-        if self.pubkey == G2::zero() {
+        if self.pot_pubkey == G2::zero() {
             return Err(CeremonyError::ZeroPubkey);
         }
         for (i, g1) in self.powers.g1.iter().enumerate() {
@@ -77,7 +78,7 @@ impl Contribution {
         }
 
         // If there is no entropy yet, all values must be one.
-        if self.pubkey == G2::one()
+        if self.pot_pubkey == G2::one()
             && self.powers.g1.iter().all(|g1| *g1 == G1::one())
             && self.powers.g2.iter().all(|g2| *g2 == G2::one())
         {
@@ -103,7 +104,7 @@ impl Contribution {
             if *g2 == G2::one() {
                 return Err(CeremonyError::InvalidG2One(i));
             }
-            if i > 1 && *g2 == self.pubkey {
+            if i > 1 && *g2 == self.pot_pubkey {
                 return Err(CeremonyError::InvalidG2Pubkey(i));
             }
             if let Some(j) = set.get(g2) {
@@ -124,7 +125,7 @@ mod test {
     fn contribution_json() {
         let value = Contribution {
             powers: Powers::new(2, 4),
-            pubkey: G2::one(),
+            pot_pubkey: G2::one(),
         };
         let json = serde_json::to_value(&value).unwrap();
         assert_eq!(
@@ -144,7 +145,7 @@ mod test {
                 "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
                 ]
             },
-            "pubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+            "potPubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
             })
         );
         let deser = serde_json::from_value::<Contribution>(json).unwrap();

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -172,7 +172,6 @@ fn random_factors(n: usize) -> (Vec<<Fr as PrimeField>::BigInt>, Fr) {
 }
 
 fn random_scalar(entropy: [u8; 32]) -> Fr {
-    // TODO: Use an explicit cryptographic rng.
     let mut rng = ChaCha20Rng::from_seed(entropy);
     Fr::rand(&mut rng)
 }

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -13,7 +13,8 @@ use ark_ec::{
     msm::VariableBaseMSM, wnaf::WnafContext, AffineCurve, PairingEngine, ProjectiveCurve,
 };
 use ark_ff::{One, PrimeField, UniformRand, Zero};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
 use std::iter;
 use tracing::instrument;
@@ -172,7 +173,7 @@ fn random_factors(n: usize) -> (Vec<<Fr as PrimeField>::BigInt>, Fr) {
 
 fn random_scalar(entropy: [u8; 32]) -> Fr {
     // TODO: Use an explicit cryptographic rng.
-    let mut rng = StdRng::from_seed(entropy);
+    let mut rng = ChaCha20Rng::from_seed(entropy);
     Fr::rand(&mut rng)
 }
 

--- a/crypto/src/engine/arkworks/zcash_format.rs
+++ b/crypto/src/engine/arkworks/zcash_format.rs
@@ -190,6 +190,12 @@ pub fn parse_g<P: SWModelParameters, const N: usize>(
         GroupAffine::<P>::get_point_from_x(x, greatest).ok_or(ParseError::InvalidXCoordinate)?;
     debug_assert!(point.is_on_curve()); // Always true
 
+    // Subgroup check is expensive and therefore not done as part of parsing.
+    // TODO: A safer API to indicate whether the check is required.
+    // if !point.is_in_correct_subgroup_assuming_on_curve() {
+    //     return Err(ParseError::InvalidSubgroup);
+    // }
+
     Ok(point)
 }
 

--- a/crypto/src/engine/arkworks/zcash_format.rs
+++ b/crypto/src/engine/arkworks/zcash_format.rs
@@ -189,9 +189,6 @@ pub fn parse_g<P: SWModelParameters, const N: usize>(
     let point =
         GroupAffine::<P>::get_point_from_x(x, greatest).ok_or(ParseError::InvalidXCoordinate)?;
     debug_assert!(point.is_on_curve()); // Always true
-    if !point.is_in_correct_subgroup_assuming_on_curve() {
-        return Err(ParseError::InvalidSubgroup);
-    }
 
     Ok(point)
 }

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -55,8 +55,8 @@ impl Transcript {
     #[must_use]
     pub fn contribution(&self) -> Contribution {
         Contribution {
-            powers: self.powers.clone(),
-            pubkey: G2::one(),
+            powers:     self.powers.clone(),
+            pot_pubkey: G2::one(),
         }
     }
 
@@ -93,13 +93,13 @@ impl Transcript {
         // Verify the contribution points (encoding and subgroup checks).
         E::validate_g1(&contribution.powers.g1)?;
         E::validate_g2(&contribution.powers.g2)?;
-        E::validate_g2(&[contribution.pubkey])?;
+        E::validate_g2(&[contribution.pot_pubkey])?;
 
         // Verify pairings.
         E::verify_pubkey(
             contribution.powers.g1[1],
             self.powers.g1[1],
-            contribution.pubkey,
+            contribution.pot_pubkey,
         )?;
         E::verify_g1(&contribution.powers.g1, contribution.powers.g2[1])?;
         E::verify_g2(
@@ -115,7 +115,7 @@ impl Transcript {
     /// verified.
     pub fn add(&mut self, contribution: Contribution) {
         self.witness.products.push(contribution.powers.g1[1]);
-        self.witness.pubkeys.push(contribution.pubkey);
+        self.witness.pubkeys.push(contribution.pot_pubkey);
         self.powers = contribution.powers;
     }
 

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -56,7 +56,7 @@ impl Transcript {
     pub fn contribution(&self) -> Contribution {
         Contribution {
             powers: self.powers.clone(),
-            pubkey: G2::one(),
+            pot_pubkey: G2::one(),
         }
     }
 
@@ -93,13 +93,13 @@ impl Transcript {
         // Verify the contribution points (encoding and subgroup checks).
         E::validate_g1(&contribution.powers.g1)?;
         E::validate_g2(&contribution.powers.g2)?;
-        E::validate_g2(&[contribution.pubkey])?;
+        E::validate_g2(&[contribution.pot_pubkey])?;
 
         // Verify pairings.
         E::verify_pubkey(
             contribution.powers.g1[1],
             self.powers.g1[1],
-            contribution.pubkey,
+            contribution.pot_pubkey,
         )?;
         E::verify_g1(&contribution.powers.g1, contribution.powers.g2[1])?;
         E::verify_g2(
@@ -115,7 +115,7 @@ impl Transcript {
     /// verified.
     pub fn add(&mut self, contribution: Contribution) {
         self.witness.products.push(contribution.powers.g1[1]);
-        self.witness.pubkeys.push(contribution.pubkey);
+        self.witness.pubkeys.push(contribution.pot_pubkey);
         self.powers = contribution.powers;
     }
 

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -56,7 +56,7 @@ impl Transcript {
     pub fn contribution(&self) -> Contribution {
         Contribution {
             powers: self.powers.clone(),
-            pot_pubkey: G2::one(),
+            pubkey: G2::one(),
         }
     }
 
@@ -93,13 +93,13 @@ impl Transcript {
         // Verify the contribution points (encoding and subgroup checks).
         E::validate_g1(&contribution.powers.g1)?;
         E::validate_g2(&contribution.powers.g2)?;
-        E::validate_g2(&[contribution.pot_pubkey])?;
+        E::validate_g2(&[contribution.pubkey])?;
 
         // Verify pairings.
         E::verify_pubkey(
             contribution.powers.g1[1],
             self.powers.g1[1],
-            contribution.pot_pubkey,
+            contribution.pubkey,
         )?;
         E::verify_g1(&contribution.powers.g1, contribution.powers.g2[1])?;
         E::verify_g2(
@@ -115,7 +115,7 @@ impl Transcript {
     /// verified.
     pub fn add(&mut self, contribution: Contribution) {
         self.witness.products.push(contribution.powers.g1[1]);
-        self.witness.pubkeys.push(contribution.pot_pubkey);
+        self.witness.pubkeys.push(contribution.pubkey);
         self.powers = contribution.powers;
     }
 

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,10 @@ processes = []
     source = "kzg_ceremony_sequencer_dev_data"
     destination = "/data"
 
+[env]
+    GH_REDIRECT_URL="https://kzg-ceremony-sequencer-dev.fly.dev/auth/callback/github"
+    ETH_REDIRECT_URL="https://kzg-ceremony-sequencer-dev.fly.dev/auth/callback/eth"
+
 # Secrets
 # - ETH_RPC_URL       (i.e. Alchemy)
 # - GH_CLIENT_ID      (Register at <https://github.com/settings/applications/new>)

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -6,20 +6,19 @@ use crate::{
     EthAuthOptions, Options, SessionId, SessionInfo,
 };
 use axum::{
-    extract::Query,
-    response::{IntoResponse, Response},
+    async_trait,
+    extract::{FromRequest, Query, RequestParts},
+    response::{IntoResponse, Redirect, Response},
     Extension, Json,
 };
 use chrono::DateTime;
 use http::StatusCode;
-use oauth2::{
-    reqwest::async_http_client, AuthorizationCode, CsrfToken, RedirectUrl, Scope, TokenResponse,
-};
+use oauth2::{reqwest::async_http_client, AuthorizationCode, CsrfToken, Scope, TokenResponse};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-use std::borrow::Cow;
+use serde_json::{json, Map, Value};
 use thiserror::Error;
 use tokio::time::Instant;
+use url::Url;
 
 // These are the providers that are supported
 // via oauth
@@ -57,9 +56,10 @@ pub enum AuthError {
     Storage(#[from] StorageError),
 }
 
-pub struct UserVerified {
-    id_token:   IdToken,
-    session_id: String,
+pub struct UserVerifiedResponse {
+    id_token:       IdToken,
+    session_id:     String,
+    as_redirect_to: Option<String>,
 }
 
 pub struct AuthUrl {
@@ -77,13 +77,28 @@ impl IntoResponse for AuthUrl {
     }
 }
 
-impl IntoResponse for UserVerified {
+impl IntoResponse for UserVerifiedResponse {
     fn into_response(self) -> Response {
-        Json(json!({
-            "id_token" : self.id_token,
-            "session_id" : self.session_id,
-        }))
-        .into_response()
+        // Handling URL parse error by ignoring it and returning without redirect – we
+        // have no better option here, since we don't know the frontend that called us.
+        let redirect_url = self.as_redirect_to.and_then(|r| Url::parse(&r).ok());
+        match redirect_url {
+            Some(mut redirect_url) => {
+                redirect_url
+                    .query_pairs_mut()
+                    .append_pair("session_id", &self.session_id)
+                    .append_pair("sub", &self.id_token.sub)
+                    .append_pair("nickname", &self.id_token.nickname)
+                    .append_pair("provider", &self.id_token.provider)
+                    .append_pair("exp", &self.id_token.exp.to_string());
+                Redirect::to(redirect_url.as_str()).into_response()
+            }
+            None => Json(json!({
+                "id_token" : self.id_token,
+                "session_id" : self.session_id,
+            }))
+            .into_response(),
+        }
     }
 }
 
@@ -139,6 +154,20 @@ pub struct AuthClientLinkQueryParams {
     redirect_to: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CsrfWithRedirect {
+    secret:   CsrfToken,
+    redirect: Option<String>,
+}
+
+impl CsrfWithRedirect {
+    fn encode_into_csrf(&self) -> CsrfToken {
+        let value = serde_json::to_string(self).unwrap();
+        let bytes = value.as_bytes();
+        CsrfToken::new(base64::encode_config(bytes, base64::URL_SAFE_NO_PAD))
+    }
+}
+
 // Returns the url that the user needs to call
 // in order to get an authorisation code
 pub async fn auth_client_link(
@@ -159,32 +188,23 @@ pub async fn auth_client_link(
         }
     }
 
-    let csrf_token = CsrfToken::new_random();
+    let csrf_secret = CsrfToken::new_random();
 
-    let redirect_uri = params
-        .redirect_to
-        .and_then(|uri| RedirectUrl::new(uri).ok()); // TODO: Error handling?
+    let csrf_with_redirect = CsrfWithRedirect {
+        secret:   csrf_secret.clone(),
+        redirect: params.redirect_to,
+    }
+    .encode_into_csrf();
 
-    let auth_request = eth_client
-        .authorize_url(|| csrf_token)
+    let eth_auth_request = eth_client
+        .authorize_url(|| csrf_with_redirect)
         .add_scope(Scope::new("openid".to_string()));
 
-    let redirected_auth_request = if let Some(redirect) = &redirect_uri {
-        auth_request.set_redirect_uri(Cow::Borrowed(redirect))
-    } else {
-        auth_request
-    };
+    let (auth_url, csrf_with_redirect) = eth_auth_request.url();
 
-    let (auth_url, csrf_token) = redirected_auth_request.url();
+    let gh_auth_request = gh_client.client.authorize_url(|| csrf_with_redirect);
 
-    let gh_auth_request = gh_client.client.authorize_url(|| csrf_token);
-    let redirected_gh_auth_request = if let Some(redirect) = &redirect_uri {
-        gh_auth_request.set_redirect_uri(Cow::Borrowed(redirect))
-    } else {
-        gh_auth_request
-    };
-
-    let (gh_url, csrf_token) = redirected_gh_auth_request.url();
+    let (gh_url, _) = gh_auth_request.url();
 
     // Store CSRF token
     // TODO These should be cleaned periodically
@@ -192,7 +212,7 @@ pub async fn auth_client_link(
         .write()
         .await
         .csrf_tokens
-        .insert(csrf_token.secret().clone());
+        .insert(csrf_secret.secret().clone());
 
     Ok(AuthUrl {
         eth_auth_url:    auth_url.to_string(),
@@ -206,9 +226,57 @@ pub async fn auth_client_link(
 // that we need to check that the user did indeed login with
 // an identity provider
 #[derive(Debug, Deserialize)]
-pub struct AuthPayload {
+pub struct RawAuthPayload {
     code:  String,
     state: String,
+}
+
+#[derive(Debug)]
+pub struct AuthPayload {
+    code:        String,
+    csrf:        CsrfToken,
+    redirect_to: Option<String>,
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for AuthPayload
+where
+    B: Send,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        let Query(raw): Query<RawAuthPayload> = Query::from_request(req)
+            .await
+            .map_err(IntoResponse::into_response)?;
+        let decoded_state =
+            base64::decode_config(raw.state, base64::URL_SAFE_NO_PAD).map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(Value::Object(Map::from_iter([(
+                        "message".to_string(),
+                        Value::String("invalid base64 data in state parameter".to_string()),
+                    )]))),
+                )
+                    .into_response()
+            })?;
+        let json_decoded_state =
+            serde_json::from_slice::<CsrfWithRedirect>(decoded_state.as_slice()).map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(Value::Object(Map::from_iter([(
+                        "message".to_string(),
+                        Value::String("invalid json in state parameter".to_string()),
+                    )]))),
+                )
+                    .into_response()
+            })?;
+        Ok(Self {
+            code:        raw.code,
+            csrf:        json_decoded_state.secret,
+            redirect_to: json_decoded_state.redirect,
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -225,14 +293,14 @@ struct GhUserInfo {
 
 #[allow(clippy::too_many_arguments)]
 pub async fn github_callback(
-    Query(payload): Query<AuthPayload>,
+    payload: AuthPayload,
     Extension(options): Extension<Options>,
     Extension(auth_state): Extension<SharedAuthState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(storage): Extension<PersistentStorage>,
     Extension(gh_oauth_client): Extension<GithubOAuthClient>,
     Extension(http_client): Extension<reqwest::Client>,
-) -> Result<UserVerified, AuthError> {
+) -> Result<UserVerifiedResponse, AuthError> {
     verify_csrf(&payload, &auth_state).await?;
     let token = gh_oauth_client
         .exchange_code(AuthorizationCode::new(payload.code))
@@ -260,7 +328,15 @@ pub async fn github_callback(
         uid:      format!("github | {}", gh_user_info.login),
         nickname: gh_user_info.login,
     };
-    post_authenticate(auth_state, lobby_state, storage, user, AuthProvider::Github).await
+    post_authenticate(
+        auth_state,
+        lobby_state,
+        storage,
+        user,
+        payload.redirect_to,
+        AuthProvider::Github,
+    )
+    .await
 }
 
 #[derive(Debug, Deserialize)]
@@ -280,14 +356,14 @@ struct EthUserInfo {
 // say they did not
 #[allow(clippy::too_many_arguments)]
 pub async fn eth_callback(
-    Query(payload): Query<AuthPayload>,
+    payload: AuthPayload,
     Extension(options): Extension<Options>,
     Extension(auth_state): Extension<SharedAuthState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(storage): Extension<PersistentStorage>,
     Extension(oauth_client): Extension<EthOAuthClient>,
     Extension(http_client): Extension<reqwest::Client>,
-) -> Result<UserVerified, AuthError> {
+) -> Result<UserVerifiedResponse, AuthError> {
     verify_csrf(&payload, &auth_state).await?;
     let token = oauth_client
         .exchange_code(AuthorizationCode::new(payload.code))
@@ -336,6 +412,7 @@ pub async fn eth_callback(
         lobby_state,
         storage,
         user_data,
+        payload.redirect_to,
         AuthProvider::Ethereum,
     )
     .await
@@ -371,7 +448,7 @@ async fn get_tx_count(
 
 async fn verify_csrf(payload: &AuthPayload, store: &SharedAuthState) -> Result<(), AuthError> {
     let auth_state = store.read().await;
-    if auth_state.csrf_tokens.contains(&payload.state) {
+    if auth_state.csrf_tokens.contains(payload.csrf.secret()) {
         Ok(())
     } else {
         Err(AuthError::InvalidCsrf)
@@ -383,8 +460,9 @@ async fn post_authenticate(
     lobby_state: SharedLobbyState,
     storage: PersistentStorage,
     user_data: AuthenticatedUser,
+    redirect_to: Option<String>,
     auth_provider: AuthProvider,
-) -> Result<UserVerified, AuthError> {
+) -> Result<UserVerifiedResponse, AuthError> {
     // Check if they have already contributed
     match storage.has_contributed(&user_data.uid).await {
         Err(error) => return Err(AuthError::Storage(error)),
@@ -424,8 +502,9 @@ async fn post_authenticate(
         });
     }
 
-    Ok(UserVerified {
+    Ok(UserVerifiedResponse {
         id_token,
         session_id: session_id.to_string(),
+        as_redirect_to: redirect_to,
     })
 }

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -1,7 +1,7 @@
 use crate::{
     io::write_json_file,
     keys::{SharedKeys, Signature, SignatureError},
-    lobby::{SharedContributorState, SharedLobbyState},
+    lobby::SharedLobbyState,
     receipt::Receipt,
     storage::{PersistentStorage, StorageError},
     Engine, Options, SessionId, SharedCeremonyStatus, SharedTranscript,
@@ -65,7 +65,6 @@ impl IntoResponse for ContributeError {
 pub async fn contribute(
     session_id: SessionId,
     Json(contribution): Json<BatchContribution>,
-    Extension(contributor_state): Extension<SharedContributorState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(options): Extension<Options>,
     Extension(shared_transcript): Extension<SharedTranscript>,
@@ -73,25 +72,21 @@ pub async fn contribute(
     Extension(num_contributions): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> Result<ContributeReceipt, ContributeError> {
-    contributor_state
+    let id_token = lobby_state
         .begin_contributing(&session_id)
         .await
-        .map_err(|_| ContributeError::NotUsersTurn)?;
+        .map_err(|_| ContributeError::NotUsersTurn)?
+        .token;
 
-    let id_token = {
-        let mut lobby = lobby_state.write().await;
-        lobby.participants.remove(&session_id).unwrap().token
-    };
-
-    // 2. Check if the program state transition was correct
     let result = {
         let mut transcript = shared_transcript.write().await;
         transcript
             .verify_add::<Engine>(contribution.clone())
             .map_err(ContributeError::InvalidContribution)
     };
+
     if let Err(e) = result {
-        contributor_state.clear().await;
+        lobby_state.clear_current_contributor().await;
         storage
             .expire_contribution(id_token.unique_identifier())
             .await?;
@@ -115,7 +110,7 @@ pub async fn contribute(
     )
     .await;
 
-    contributor_state.clear().await;
+    lobby_state.clear_current_contributor().await;
     storage.finish_contribution(&session_id.0).await?;
 
     num_contributions.fetch_add(1, Ordering::Relaxed);
@@ -128,20 +123,14 @@ pub async fn contribute(
 
 pub async fn contribute_abort(
     session_id: SessionId,
-    Extension(contributor_state): Extension<SharedContributorState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(storage): Extension<PersistentStorage>,
 ) -> Result<(), ContributeError> {
-    contributor_state
-        .abort(&session_id)
+    lobby_state
+        .abort_contribution(&session_id)
         .await
         .map_err(|_| ContributeError::NotUsersTurn)?;
-
-    let mut lobby = lobby_state.write().await;
-    lobby.participants.remove(&session_id);
-
     storage.expire_contribution(&session_id.0).await?;
-
     Ok(())
 }
 
@@ -157,7 +146,7 @@ mod tests {
         io::read_json_file,
         keys,
         keys::SharedKeys,
-        lobby::SharedContributorState,
+        lobby::SharedLobbyState,
         storage::storage_client,
         test_util::{create_test_session_info, test_options},
         tests::{invalid_contribution, test_transcript, valid_contribution},
@@ -181,14 +170,12 @@ mod tests {
     async fn rejects_out_of_turn_contribution() {
         let opts = test_options();
         let db = storage_client(&opts.storage).await.unwrap();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let transcript = test_transcript();
         let contrbution = valid_contribution(&transcript, 1);
         let result = contribute(
             SessionId::new(),
             Json(contrbution),
-            Extension(contributor_state),
             Extension(lobby_state),
             Extension(opts),
             Extension(Arc::new(RwLock::new(transcript))),
@@ -204,16 +191,12 @@ mod tests {
     async fn rejects_invalid_contribution() {
         let opts = test_options();
         let db = storage_client(&opts.storage).await.unwrap();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let participant = SessionId::new();
-        {
-            let mut lobby = lobby_state.write().await;
-            lobby
-                .participants
-                .insert(participant.clone(), create_test_session_info(100));
-        }
-        contributor_state
+        lobby_state
+            .insert_participant(participant.clone(), create_test_session_info(100))
+            .await;
+        lobby_state
             .set_current_contributor(&participant, opts.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
@@ -222,7 +205,6 @@ mod tests {
         let result = contribute(
             participant,
             Json(contribution),
-            Extension(contributor_state),
             Extension(lobby_state),
             Extension(opts),
             Extension(Arc::new(RwLock::new(transcript))),
@@ -240,7 +222,6 @@ mod tests {
     #[tokio::test]
     async fn accepts_valid_contribution() {
         let keys = shared_keys();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let participant = SessionId::new();
         let cfg = test_options();
@@ -264,20 +245,17 @@ mod tests {
         };
         let shared_transcript = Arc::new(RwLock::new(transcript));
 
-        {
-            let mut lobby = lobby_state.write().await;
-            lobby
-                .participants
-                .insert(participant.clone(), create_test_session_info(100));
-        }
-        contributor_state
+        lobby_state
+            .insert_participant(participant.clone(), create_test_session_info(100))
+            .await;
+
+        lobby_state
             .set_current_contributor(&participant, cfg.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
         let result = contribute(
             participant.clone(),
             Json(contribution_1),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(cfg.clone()),
             Extension(shared_transcript.clone()),
@@ -290,20 +268,17 @@ mod tests {
         assert!(matches!(result, Ok(_)));
         let transcript = read_json_file::<BatchTranscript>(cfg.transcript_file.clone()).await;
         assert_eq!(transcript, transcript_1);
-        {
-            let mut lobby = lobby_state.write().await;
-            lobby
-                .participants
-                .insert(participant.clone(), create_test_session_info(100));
-        }
-        contributor_state
+        lobby_state
+            .insert_participant(participant.clone(), create_test_session_info(100))
+            .await;
+
+        lobby_state
             .set_current_contributor(&participant, cfg.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
         let result = contribute(
             participant.clone(),
             Json(contribution_2),
-            Extension(contributor_state.clone()),
             Extension(lobby_state),
             Extension(cfg.clone()),
             Extension(shared_transcript.clone()),
@@ -321,7 +296,6 @@ mod tests {
     #[tokio::test]
     async fn aborts_contribution() {
         let opts = test_options();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let transcript = Arc::new(RwLock::new(test_transcript()));
         let db = storage_client(&opts.storage).await.unwrap();
@@ -329,25 +303,20 @@ mod tests {
         let session_id = SessionId::new();
         let other_session_id = SessionId::new();
 
-        // add two participants to lobby
-        {
-            let mut state = lobby_state.write().await;
-            state
-                .participants
-                .insert(session_id.clone(), create_test_session_info(100));
-            state
-                .participants
-                .insert(other_session_id.clone(), create_test_session_info(100));
-        }
+        lobby_state
+            .insert_participant(session_id.clone(), create_test_session_info(100))
+            .await;
+        lobby_state
+            .insert_participant(other_session_id.clone(), create_test_session_info(100))
+            .await;
 
-        contributor_state
+        lobby_state
             .set_current_contributor(&session_id, opts.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
 
         let contribution_in_progress_response = try_contribute(
             other_session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -362,7 +331,6 @@ mod tests {
 
         contribute_abort(
             session_id,
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
         )
@@ -374,7 +342,6 @@ mod tests {
 
         let success_response = try_contribute(
             other_session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),

--- a/src/api/v1/info.rs
+++ b/src/api/v1/info.rs
@@ -33,10 +33,7 @@ pub async fn status(
     Extension(ceremony_status): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> StatusResponse {
-    let lobby_size = {
-        let state = lobby_state.read().await;
-        state.participants.len()
-    };
+    let lobby_size = lobby_state.get_lobby_size().await;
 
     let num_contributions = ceremony_status.load(Ordering::Relaxed);
     let sequencer_address = keys.address();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     io::{read_or_create_transcript, CeremonySizes},
     keys::Keys,
-    lobby::{clear_lobby_on_interval, SharedContributorState, SharedLobbyState},
+    lobby::{clear_lobby_on_interval, SharedLobbyState},
     oauth::{
         eth_oauth_client, github_oauth_client, EthAuthOptions, GithubAuthOptions, SharedAuthState,
     },
@@ -60,7 +60,7 @@ pub type SharedTranscript = Arc<RwLock<BatchTranscript>>;
 pub type SharedCeremonyStatus = Arc<AtomicUsize>;
 
 pub const DEFAULT_CEREMONY_SIZES: &str = "4096,65:8192,65:16384,65:32768,65";
-pub const MAX_CONTRIBUTION_SIZE: usize = 10485760; // 10MB
+pub const MAX_CONTRIBUTION_SIZE: usize = 10_485_760; // 10MB
 
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 pub struct Options {
@@ -117,8 +117,6 @@ pub async fn start_server(
     )
     .await?;
 
-    let active_contributor_state = SharedContributorState::default();
-
     // TODO: figure it out from the transcript
     let ceremony_status = Arc::new(AtomicUsize::new(0));
     let lobby_state = SharedLobbyState::default();
@@ -142,7 +140,6 @@ pub async fn start_server(
         .route("/info/status", get(status))
         .route("/info/current_state", get(current_state))
         .layer(CorsLayer::permissive())
-        .layer(Extension(active_contributor_state))
         .layer(Extension(lobby_state))
         .layer(Extension(auth_state))
         .layer(Extension(ceremony_status))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use std::{
     sync::{atomic::AtomicUsize, Arc},
 };
 use tokio::sync::RwLock;
-use tower_http::trace::TraceLayer;
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing::info;
 use url::Url;
 
@@ -141,6 +141,7 @@ pub async fn start_server(
         .route("/contribute/abort", post(contribute_abort))
         .route("/info/status", get(status))
         .route("/info/current_state", get(current_state))
+        .layer(CorsLayer::permissive())
         .layer(Extension(active_contributor_state))
         .layer(Extension(lobby_state))
         .layer(Extension(auth_state))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@ pub async fn start_server(
     ));
 
     let app = Router::new()
-        .layer(TraceLayer::new_for_http())
         .route("/hello_world", get(hello_world))
         .route("/auth/request_link", get(auth_client_link))
         .route("/auth/callback/github", get(github_callback))
@@ -151,7 +150,8 @@ pub async fn start_server(
         .layer(Extension(reqwest::Client::new()))
         .layer(Extension(storage_client(&options.storage).await?))
         .layer(Extension(transcript))
-        .layer(Extension(options.clone()));
+        .layer(Extension(options.clone()))
+        .layer(TraceLayer::new_for_http());
 
     // Run the server
     let (addr, prefix) = parse_url(&options.server)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ mod tests {
 
     pub fn invalid_contribution(transcript: &BatchTranscript, no: u8) -> BatchContribution {
         let mut contribution = valid_contribution(transcript, no);
-        contribution.contributions[0].pot_pubkey = G2::zero();
+        contribution.contributions[0].pubkey = G2::zero();
         contribution
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ mod tests {
 
     pub fn invalid_contribution(transcript: &BatchTranscript, no: u8) -> BatchContribution {
         let mut contribution = valid_contribution(transcript, no);
-        contribution.contributions[0].pubkey = G2::zero();
+        contribution.contributions[0].pot_pubkey = G2::zero();
         contribution
     }
 }

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -3,12 +3,11 @@ use crate::{
     storage::PersistentStorage,
 };
 use clap::Parser;
-use std::{collections::BTreeMap, num::ParseIntError, str::FromStr, sync::Arc, time::Duration};
-use thiserror::Error;
-use tokio::{
-    sync::{Mutex, RwLock},
-    time::Instant,
+use std::{
+    collections::BTreeMap, mem, num::ParseIntError, str::FromStr, sync::Arc, time::Duration,
 };
+use thiserror::Error;
+use tokio::{sync::Mutex, time::Instant};
 
 fn duration_from_str(value: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_secs(u64::from_str(value)?))
@@ -34,13 +33,20 @@ pub struct Options {
 
 #[derive(Default)]
 pub struct LobbyState {
-    pub participants: BTreeMap<SessionId, SessionInfo>,
+    pub participants:       BTreeMap<SessionId, SessionInfo>,
+    pub active_contributor: ActiveContributor,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionInfoWithId {
+    id:   SessionId,
+    info: SessionInfo,
 }
 
 pub enum ActiveContributor {
     None,
-    AwaitingContribution(SessionId),
-    Contributing(SessionId),
+    AwaitingContribution(SessionInfoWithId),
+    Contributing(SessionInfoWithId),
 }
 
 impl Default for ActiveContributor {
@@ -55,14 +61,16 @@ pub enum ActiveContributorError {
     AnotherContributionInProgress,
     #[error("not user's turn")]
     NotUsersTurn,
+    #[error("user not in the lobby")]
+    UserNotInLobby,
 }
 
 #[derive(Clone, Default)]
-pub struct SharedContributorState {
-    inner: Arc<Mutex<ActiveContributor>>,
+pub struct SharedLobbyState {
+    inner: Arc<Mutex<LobbyState>>,
 }
 
-impl SharedContributorState {
+impl SharedLobbyState {
     pub async fn set_current_contributor(
         &self,
         participant: &SessionId,
@@ -70,8 +78,17 @@ impl SharedContributorState {
         storage: PersistentStorage,
     ) -> Result<(), ActiveContributorError> {
         let mut state = self.inner.lock().await;
-        if matches!(*state, ActiveContributor::None) {
-            *state = ActiveContributor::AwaitingContribution(participant.clone());
+
+        if matches!(state.active_contributor, ActiveContributor::None) {
+            let session_info = state
+                .participants
+                .remove(participant)
+                .ok_or(ActiveContributorError::UserNotInLobby)?;
+
+            state.active_contributor = ActiveContributor::AwaitingContribution(SessionInfoWithId {
+                id:   participant.clone(),
+                info: session_info,
+            });
 
             let inner = self.inner.clone();
             let participant = participant.clone();
@@ -92,37 +109,84 @@ impl SharedContributorState {
     pub async fn begin_contributing(
         &self,
         participant: &SessionId,
+    ) -> Result<SessionInfo, ActiveContributorError> {
+        let mut state = self.inner.lock().await;
+
+        match mem::replace(&mut state.active_contributor, ActiveContributor::None) {
+            ActiveContributor::AwaitingContribution(info) if &info.id == participant => {
+                state.active_contributor = ActiveContributor::Contributing(info.clone());
+                Ok(info.info)
+            }
+            other => {
+                state.active_contributor = other;
+                Err(ActiveContributorError::NotUsersTurn)
+            }
+        }
+    }
+
+    pub async fn abort_contribution(
+        &self,
+        participant: &SessionId,
     ) -> Result<(), ActiveContributorError> {
         let mut state = self.inner.lock().await;
 
-        if !matches!(&*state, ActiveContributor::AwaitingContribution(x) if x == participant) {
+        if !matches!(&state.active_contributor, ActiveContributor::AwaitingContribution(x) if &x.id == participant)
+        {
             return Err(ActiveContributorError::NotUsersTurn);
         }
 
-        *state = ActiveContributor::Contributing(participant.clone());
+        state.active_contributor = ActiveContributor::None;
 
         Ok(())
     }
 
-    pub async fn abort(&self, participant: &SessionId) -> Result<(), ActiveContributorError> {
+    pub async fn clear_current_contributor(&self) {
         let mut state = self.inner.lock().await;
-
-        if !matches!(&*state, ActiveContributor::AwaitingContribution(x) if x == participant) {
-            return Err(ActiveContributorError::NotUsersTurn);
-        }
-
-        *state = ActiveContributor::None;
-
-        Ok(())
+        state.active_contributor = ActiveContributor::None;
     }
 
-    pub async fn clear(&self) {
-        let mut state = self.inner.lock().await;
-        *state = ActiveContributor::None;
+    pub async fn clear_lobby(&self, predicate: impl Fn(&SessionInfo) -> bool + Send) {
+        let mut lobby_state = self.inner.lock().await;
+        lobby_state.participants.retain(|_, info| !predicate(info));
+    }
+
+    pub async fn modify_participant<R>(
+        &self,
+        session_id: &SessionId,
+        fun: impl FnOnce(&mut SessionInfo) -> R,
+    ) -> Option<R> {
+        let mut lobby_state = self.inner.lock().await;
+        lobby_state.participants.get_mut(session_id).map(fun)
+    }
+
+    pub async fn get_lobby_size(&self) -> usize {
+        self.inner.lock().await.participants.len()
+    }
+
+    pub async fn insert_participant(&self, session_id: SessionId, session_info: SessionInfo) {
+        self.inner
+            .lock()
+            .await
+            .participants
+            .insert(session_id, session_info);
+    }
+
+    #[cfg(test)]
+    pub async fn get_all_participants(&self) -> Vec<SessionInfoWithId> {
+        self.inner
+            .lock()
+            .await
+            .participants
+            .iter()
+            .map(|(id, info)| SessionInfoWithId {
+                id:   id.clone(),
+                info: info.clone(),
+            })
+            .collect()
     }
 
     async fn expire_current_contributor(
-        inner: Arc<Mutex<ActiveContributor>>,
+        inner: Arc<Mutex<LobbyState>>,
         participant: SessionId,
         compute_deadline: Duration,
         storage: PersistentStorage,
@@ -131,16 +195,15 @@ impl SharedContributorState {
 
         let mut state = inner.lock().await;
 
-        if matches!(&*state, ActiveContributor::AwaitingContribution(x) if x == &participant) {
-            *state = ActiveContributor::None;
+        if matches!(&state.active_contributor, ActiveContributor::AwaitingContribution(x) if x.id == participant)
+        {
+            state.active_contributor = ActiveContributor::None;
 
             drop(state);
             storage.expire_contribution(&participant.0).await.unwrap();
         }
     }
 }
-
-pub type SharedLobbyState = Arc<RwLock<LobbyState>>;
 
 pub async fn clear_lobby_on_interval(state: SharedLobbyState, options: Options) {
     let max_diff = options.lobby_checkin_frequency + options.lobby_checkin_tolerance;
@@ -157,33 +220,7 @@ pub async fn clear_lobby_on_interval(state: SharedLobbyState, options: Options) 
             time_diff > max_diff
         };
 
-        let clone = state.clone();
-        clear_lobby(clone, predicate).await;
-    }
-}
-
-async fn clear_lobby(state: SharedLobbyState, predicate: impl Fn(&SessionInfo) -> bool + Send) {
-    let mut lobby_state = state.write().await;
-
-    // Iterate top `MAX_LOBBY_SIZE` participants and check if they have
-    let participants = lobby_state.participants.keys().cloned();
-    let mut sessions_to_kick = Vec::new();
-
-    for participant in participants {
-        // Check if they are over their ping deadline
-        lobby_state.participants.get(&participant).map_or_else(
-            ||
-                // This should not be possible
-                tracing::debug!("session id in queue but not a valid session"),
-            |session_info| {
-                if predicate(session_info) {
-                    sessions_to_kick.push(participant);
-                }
-            },
-        );
-    }
-    for session_id in sessions_to_kick {
-        lobby_state.participants.remove(&session_id);
+        state.clear_lobby(predicate).await;
     }
 }
 
@@ -206,12 +243,10 @@ async fn flush_on_predicate() {
     let arc_state = SharedLobbyState::default();
 
     {
-        let mut state = arc_state.write().await;
-
         for i in 0..to_add {
             let id = SessionId::new();
             let session_info = create_test_session_info(i as u64);
-            state.participants.insert(id, session_info);
+            arc_state.insert_participant(id, session_info).await;
         }
     }
 
@@ -219,17 +254,15 @@ async fn flush_on_predicate() {
     // expiry which is an even number
     let predicate = |session_info: &SessionInfo| -> bool { session_info.token.exp % 2 == 0 };
 
-    clear_lobby(arc_state.clone(), predicate).await;
+    arc_state.clear_lobby(predicate).await;
 
     // Now we expect that half of the lobby should be
     // kicked
-    let state = arc_state.write().await;
-    assert_eq!(state.participants.len(), to_add / 2);
+    let participants = arc_state.get_all_participants().await;
+    assert_eq!(participants.len(), to_add / 2);
 
-    let session_ids = state.participants.keys().cloned();
-    for id in session_ids {
-        let info = state.participants.get(&id).unwrap();
+    for participant in participants {
         // We should just be left with `exp` numbers which are odd
-        assert_eq!(info.token.exp % 2, 1);
+        assert_eq!(participant.info.token.exp % 2, 1);
     }
 }

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -2,10 +2,7 @@ mod ethereum;
 mod github;
 
 use crate::sessions::SessionId;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::RwLock;
 
 pub use self::{
@@ -15,13 +12,9 @@ pub use self::{
 
 pub type SharedAuthState = Arc<RwLock<AuthState>>;
 pub type IdTokenSub = String;
-pub type CsrfToken = String;
 
 #[derive(Default)]
 pub struct AuthState {
-    // CSRF tokens for oAUTH
-    pub csrf_tokens: BTreeSet<CsrfToken>,
-
     // A map between a users unique social id
     // and their session.
     // We use this to check if a user has already entered the lobby

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -244,7 +244,7 @@ async fn contribute_successfully(
         contribution
             .contributions
             .iter()
-            .map(|c| c.pubkey)
+            .map(|c| c.pot_pubkey)
             .collect::<Vec<_>>()
     )
 }
@@ -256,7 +256,7 @@ fn assert_includes_contribution(transcript: &BatchTranscript, contribution: &Bat
         .zip(contribution.contributions.iter())
         .for_each(|(t, c)| {
             assert!(t.witness.products.contains(&c.powers.g1[0]));
-            assert!(t.witness.pubkeys.contains(&c.pubkey));
+            assert!(t.witness.pubkeys.contains(&c.pot_pubkey));
         })
 }
 
@@ -318,7 +318,7 @@ async fn test_contribution_happy_path() {
     let contrib_pubkeys = contribution
         .contributions
         .iter()
-        .map(|contribution| contribution.pubkey)
+        .map(|contribution| contribution.pot_pubkey)
         .collect::<Vec<_>>();
     let transcript_pubkeys = transcript
         .transcripts

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -244,7 +244,7 @@ async fn contribute_successfully(
         contribution
             .contributions
             .iter()
-            .map(|c| c.pot_pubkey)
+            .map(|c| c.pubkey)
             .collect::<Vec<_>>()
     )
 }
@@ -256,7 +256,7 @@ fn assert_includes_contribution(transcript: &BatchTranscript, contribution: &Bat
         .zip(contribution.contributions.iter())
         .for_each(|(t, c)| {
             assert!(t.witness.products.contains(&c.powers.g1[0]));
-            assert!(t.witness.pubkeys.contains(&c.pot_pubkey));
+            assert!(t.witness.pubkeys.contains(&c.pubkey));
         })
 }
 
@@ -318,7 +318,7 @@ async fn test_contribution_happy_path() {
     let contrib_pubkeys = contribution
         .contributions
         .iter()
-        .map(|contribution| contribution.pot_pubkey)
+        .map(|contribution| contribution.pubkey)
         .collect::<Vec<_>>();
     let transcript_pubkeys = transcript
         .transcripts

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -486,10 +486,9 @@ async fn test_large_lobby() {
             tokio::spawn(async move {
                 well_behaved_participant(h.as_ref(), c.as_ref(), format!("user {i}")).await
             })
-        })
-        .collect::<Vec<_>>();
+        });
 
-    let contributions: Vec<_> = futures::future::join_all(handles.into_iter())
+    let contributions: Vec<_> = futures::future::join_all(handles)
         .await
         .into_iter()
         .map(|r| r.expect("must terminate successfully"))
@@ -520,10 +519,9 @@ async fn test_large_lobby_with_misbehaving_users() {
                     None
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        });
 
-    let contributions: Vec<_> = futures::future::join_all(handles.into_iter())
+    let contributions: Vec<_> = futures::future::join_all(handles)
         .await
         .into_iter()
         .map(|r| r.expect("must terminate successfully"))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/ethereum/kzg-ceremony-sequencer/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Need to make sure that the entropy is dropped after each contribution is made in the `batch_contribution` and use a more secure rng.

## Solution

* Zeroize the toxic waste after each contribution is made 
* Switch from `StdRng` to `Chacha20Rng`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
