### PR TITLE
Deferred pairing-checks and used pairing products when possible

### DIFF
--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -31,19 +31,43 @@ pub trait Engine {
     /// from `previous` to `tau`.
     fn verify_pubkey(tau: G1, previous: G1, pubkey: G2) -> Result<(), CeremonyError>;
 
+    /// Verify that the pubkey contains the contribution added
+    /// from `previous` to `tau`.
+    ///
+    /// Deferring pairing product check.
+    fn verify_pubkey_defer_pairing(
+        tau: G1,
+        previous: G1,
+        pubkey: G2,
+    ) -> Result<(Vec<G1>, Vec<G2>), CeremonyError>;
+
     /// Verify that `powers` contains a sequence of powers of `tau`.
     fn verify_g1(powers: &[G1], tau: G2) -> Result<(), CeremonyError>;
 
+    /// Verify that `powers` contains a sequence of powers of `tau`.
+    ///
+    /// Deferring pairing product check.
+    fn verify_g1_defer_pairing(powers: &[G1], tau: G2)
+        -> Result<(Vec<G1>, Vec<G2>), CeremonyError>;
+
     /// Verify that `g1` and `g2` contain the same values.
     fn verify_g2(g1: &[G1], g2: &[G2]) -> Result<(), CeremonyError>;
+
+    /// Verify that `g1` and `g2` contain the same values.
+    ///
+    /// Deferring pairing product check.
+    fn verify_g2_defer_pairing(g1: &[G1], g2: &[G2]) -> Result<(Vec<G1>, Vec<G2>), CeremonyError>;
 
     /// Derive a secret scalar $τ$ from the given entropy and multiply elements
     /// of `powers` by powers of $τ$.
     fn add_entropy_g1(entropy: [u8; 32], powers: &mut [G1]) -> Result<(), CeremonyError>;
 
-    /// Derive a secret scalar $τ4 from the given entropy and multiply elements
+    /// Derive a secret scalar $τ$ from the given entropy and multiply elements
     /// of `powers` by powers of $τ$.
     fn add_entropy_g2(entropy: [u8; 32], powers: &mut [G2]) -> Result<(), CeremonyError>;
+
+    /// Assert the pairing product of the inputs is one.
+    fn pairing_products_is_one(g1: &[G1], g2: &[G2]) -> Result<bool, CeremonyError>;
 }
 
 #[cfg(feature = "bench")]

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -42,6 +42,8 @@ pub enum CeremonyError {
     G1PairingFailed,
     #[error("G2 pairing check failed")]
     G2PairingFailed,
+    #[error("Deferred pairing check failed")]
+    DeferredPairingFailed,
     #[error("pubkey is zero")]
     ZeroPubkey,
     #[error("g1[{0}] is zero")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/ethereum/kzg-ceremony-sequencer/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

The current verification needs to perform 3 pairing checks. But in face we can defer the pairing checks and linear combine them into 1 pairing check to improve the performance.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

* Defer pairing checks for G1, G2, and pubkey and combine them into 1 pairing check

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
